### PR TITLE
Bump dependencies to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.24.0
-responses==0.10.14
-pytest-cov==2.8.1
+requests==2.26.0
+responses==0.14.0
+pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        'requests==2.24.0'
+        'requests==2.26.0'
     ]
 )


### PR DESCRIPTION
The newest versions are:

* `requests==2.26.0`
* `responses==0.14.0`
* `pytest-cov==3.0.0`
