### PR TITLE
Use b prefix instead of encoding strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Camunda provides functionality to start a process instance for a given process d
 
 To start a process instance, we can use `start_process()` from [engine_client.py](./camunda/client/engine_client.py#L24)
 
-You can find an usage example [here](./examples/start_process.py).
+You can find a usage example [here](./examples/start_process.py).
 
 ```python
 client = EngineClient()
@@ -184,7 +184,7 @@ We can correlate the message by:
 - business_key
 - process_variables
 
-You can find an usage example [here](./examples/correlate_message.py).
+You can find a usage example [here](./examples/correlate_message.py).
 
 ```python
 client = EngineClient()

--- a/camunda/client/tests/test_engine_client.py
+++ b/camunda/client/tests/test_engine_client.py
@@ -201,7 +201,7 @@ class EngineClientTest(TestCase):
         variable_name = "var1"
         process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"
         resp_frame_payload = {"value": None, "valueInfo": {}, "type": ""}
-        resp_data_payload = base64.decodebytes("hellocamunda".encode())
+        resp_data_payload = base64.decodebytes(b"hellocamunda")
         process_instance_var_data_url = f"{process_instance_var_url}/data"
 
         responses.add(responses.GET, process_instance_var_url, status=HTTPStatus.OK, json=resp_frame_payload)
@@ -216,7 +216,7 @@ class EngineClientTest(TestCase):
         variable_name = "var1"
         process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"
         resp_frame_payload = {"value": None, "valueInfo": {}, "type": ""}
-        resp_data_payload = base64.decodebytes("hellocamunda".encode())
+        resp_data_payload = base64.decodebytes(b"hellocamunda")
         process_instance_var_data_url = f"{process_instance_var_url}/data"
 
         responses.add(responses.GET, process_instance_var_url, status=HTTPStatus.OK, json=resp_frame_payload)


### PR DESCRIPTION
We can use bytes literals instead of encoding hardcoded strings.

https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals

Also fix a couple of README typos.