### PR TITLE
Fix for return of nested dict #73

### DIFF
--- a/camunda/variables/tests/test_variables.py
+++ b/camunda/variables/tests/test_variables.py
@@ -31,6 +31,11 @@ class VariablesTest(TestCase):
         variables = {}
         self.assertDictEqual({}, Variables.format(variables))
 
+    def test_format_returns_dict_with_value_when_nested_dict(self):
+        var1_raw = {"var2": 1, "var3": "test"}
+        variables = {"var1": var1_raw}
+        self.assertDictEqual({"var1": {"value": var1_raw}}, Variables.format(variables))
+
     def test_format_returns_formatted_variables_when_variables_present(self):
         variables = {"var1": 1, "var2": True, "var3": "string"}
         formatted_vars = Variables.format(variables)
@@ -51,3 +56,5 @@ class VariablesTest(TestCase):
                                "var2": {"value": True},
                                "var3": {"value": "string"}})
         self.assertDictEqual({"var1": 1, "var2": True, "var3": "string"}, variables.to_dict())
+
+

--- a/camunda/variables/variables.py
+++ b/camunda/variables/variables.py
@@ -26,7 +26,7 @@ class Variables:
         formatted_vars = {}
         if variables:
             formatted_vars = {
-                k: v if isinstance(v, dict) else {"value": v}
+                k: v if (isinstance(v, dict) and "value" in v.keys()) else {"value": v}
                 for k, v in variables.items()
             }
         return formatted_vars


### PR DESCRIPTION
Change variables.py to check if "value" is in keys, otherwise it will be added.
Add test_format_returns_dict_with_value_when_nested_dict for testing nested dict.