### PR TITLE
feat: added bearer token/oauth2session support

### DIFF
--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -8,6 +8,7 @@ from camunda.utils.log_utils import log_with_context
 from camunda.utils.response_utils import raise_exception_if_not_ok
 from camunda.utils.utils import str_to_list
 from camunda.utils.auth_basic import AuthBasic, obfuscate_password
+from camunda.utils.auth_bearer import AuthBearer
 from camunda.variables.variables import Variables
 
 logger = logging.getLogger(__name__)
@@ -137,12 +138,21 @@ class ExternalTaskClient:
         token = AuthBasic(**self.config.get("auth_basic").copy()).token
         return {"Authorization": token}
 
+    @property
+    def auth_bearer(self) -> dict:
+        if not self.config.get("auth_bearer") or not isinstance(self.config.get("auth_bearer"), dict):
+            return {}
+        token = AuthBearer(access_token=self.config.get("auth_bearer")).access_token
+        return {"Authorization": token}
+
     def _get_headers(self):
         headers = {
             "Content-Type": "application/json"
         }
         if self.auth_basic:
             headers.update(self.auth_basic)
+        if self.auth_bearer:
+            headers.update(self.auth_bearer)
         return headers
 
     def _log_with_context(self, msg, log_level='info', **kwargs):

--- a/camunda/utils/auth_bearer.py
+++ b/camunda/utils/auth_bearer.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, validator
+
+
+class AuthBearer(BaseModel):
+    access_token: str
+
+    @validator('access_token')
+    @classmethod
+    def concat_bearer(cls, value: str) -> str:
+        return f'Bearer {value}'


### PR DESCRIPTION
This PR implements the authorization using bearer token.

The user only should pass the access token to client property.

When the request object is an `OAuth2Session`

```python
client = ExternalTaskClient(worker_id=1)
client.auth_bearer = oauth2session.token
```