### PR TITLE
feat: added "usePriority", "variables" and "deserializeValues" in request body

### DIFF
--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -46,7 +46,8 @@ class ExternalTaskClient:
             "maxTasks": self.config["maxTasks"],
             "topics": self._get_topics(topic_names, process_variables, variables),
             "asyncResponseTimeout": self.config["asyncResponseTimeout"],
-            "usePriority": str(bool(use_priority)).lower()
+            "usePriority": str(bool(use_priority)).lower() # convert to string to make it JSON serializable
+                                                           # this value should be in lower case
         }
 
         if self.is_debug:

--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -23,7 +23,9 @@ class ExternalTaskClient:
         "retryTimeout": 300000,
         "httpTimeoutMillis": 30000,
         "timeoutDeltaMillis": 5000,
-        "includeExtensionProperties": True  # enables Camunda Extension Properties
+        "includeExtensionProperties": True,  # enables Camunda Extension Properties
+        "deserializeValues": True,  # deserialize values when fetch a task by default
+        "usePriority": False
     }
 
     def __init__(self, worker_id, engine_base_url=ENGINE_LOCAL_BASE_URL, config=None):
@@ -39,15 +41,14 @@ class ExternalTaskClient:
     def get_fetch_and_lock_url(self):
         return f"{self.external_task_base_url}/fetchAndLock"
 
-    def fetch_and_lock(self, topic_names, process_variables=None, variables=None, use_priority=False):
+    def fetch_and_lock(self, topic_names, process_variables=None, variables=None):
         url = self.get_fetch_and_lock_url()
         body = {
             "workerId": str(self.worker_id),  # convert to string to make it JSON serializable
             "maxTasks": self.config["maxTasks"],
             "topics": self._get_topics(topic_names, process_variables, variables),
             "asyncResponseTimeout": self.config["asyncResponseTimeout"],
-            "usePriority": str(bool(use_priority)).lower() # convert to string to make it JSON serializable
-                                                           # this value should be in lower case
+            "usePriority": self.config["usePriority"]
         }
 
         if self.is_debug:
@@ -74,6 +75,7 @@ class ExternalTaskClient:
                 "processVariables": process_variables if process_variables else {},
                 # enables Camunda Extension Properties
                 "includeExtensionProperties": self.config.get("includeExtensionProperties") or False,
+                "deserializeValues": self.config["deserializeValues"],
                 "variables": variables
             })
         return topics

--- a/camunda/external_task/external_task_worker.py
+++ b/camunda/external_task/external_task_worker.py
@@ -19,15 +19,17 @@ class ExternalTaskWorker:
         self.config = config
         self._log_with_context(f"Created new External Task Worker with config: {obfuscate_password(self.config)}")
 
-    def subscribe(self, topic_names, action, process_variables=None):
+    def subscribe(self, topic_names, action, process_variables=None, variables=None, use_priority=False):
         while True:
-            self._fetch_and_execute_safe(topic_names, action, process_variables)
+            self._fetch_and_execute_safe(topic_names, action, process_variables, variables, use_priority)
 
         self._log_with_context("Stopping worker")  # Fixme: This code seems to be unreachable?
 
-    def _fetch_and_execute_safe(self, topic_names, action, process_variables=None):
+    def _fetch_and_execute_safe(
+        self, topic_names, action, process_variables=None, variables=None, use_priority=False
+    ):
         try:
-            self.fetch_and_execute(topic_names, action, process_variables)
+            self.fetch_and_execute(topic_names, action, process_variables, variables, use_priority)
         except NoExternalTaskFound:
             self._log_with_context(f"no External Task found for Topics: {topic_names}, "
                                    f"Process variables: {process_variables}", topic=topic_names)
@@ -38,20 +40,20 @@ class ExternalTaskWorker:
                                    f'retrying after {sleep_seconds} seconds', exc_info=True)
             time.sleep(sleep_seconds)
 
-    def fetch_and_execute(self, topic_names, action, process_variables=None):
+    def fetch_and_execute(self, topic_names, action, process_variables=None, variables=None, use_priority=False):
         self._log_with_context(f"Fetching and Executing external tasks for Topics: {topic_names} "
                                f"with Process variables: {process_variables}")
-        resp_json = self._fetch_and_lock(topic_names, process_variables)
+        resp_json = self._fetch_and_lock(topic_names, process_variables, variables, use_priority)
         tasks = self._parse_response(resp_json, topic_names, process_variables)
         if len(tasks) == 0:
             raise NoExternalTaskFound(f"no External Task found for Topics: {topic_names}, "
                                       f"Process variables: {process_variables}")
         self._execute_tasks(tasks, action)
 
-    def _fetch_and_lock(self, topic_names, process_variables=None):
+    def _fetch_and_lock(self, topic_names, process_variables=None, variables=None, use_priority=False):
         self._log_with_context(f"Fetching and Locking external tasks for Topics: {topic_names} "
                                f"with Process variables: {process_variables}")
-        return self.client.fetch_and_lock(topic_names, process_variables)
+        return self.client.fetch_and_lock(topic_names, process_variables, variables, use_priority)
 
     def _parse_response(self, resp_json, topic_names, process_variables):
         tasks = []

--- a/camunda/external_task/external_task_worker.py
+++ b/camunda/external_task/external_task_worker.py
@@ -19,17 +19,17 @@ class ExternalTaskWorker:
         self.config = config
         self._log_with_context(f"Created new External Task Worker with config: {obfuscate_password(self.config)}")
 
-    def subscribe(self, topic_names, action, process_variables=None, variables=None, use_priority=False):
+    def subscribe(self, topic_names, action, process_variables=None, variables=None):
         while True:
-            self._fetch_and_execute_safe(topic_names, action, process_variables, variables, use_priority)
+            self._fetch_and_execute_safe(topic_names, action, process_variables, variables)
 
         self._log_with_context("Stopping worker")  # Fixme: This code seems to be unreachable?
 
     def _fetch_and_execute_safe(
-        self, topic_names, action, process_variables=None, variables=None, use_priority=False
+        self, topic_names, action, process_variables=None, variables=None
     ):
         try:
-            self.fetch_and_execute(topic_names, action, process_variables, variables, use_priority)
+            self.fetch_and_execute(topic_names, action, process_variables, variables)
         except NoExternalTaskFound:
             self._log_with_context(f"no External Task found for Topics: {topic_names}, "
                                    f"Process variables: {process_variables}", topic=topic_names)
@@ -40,20 +40,20 @@ class ExternalTaskWorker:
                                    f'retrying after {sleep_seconds} seconds', exc_info=True)
             time.sleep(sleep_seconds)
 
-    def fetch_and_execute(self, topic_names, action, process_variables=None, variables=None, use_priority=False):
+    def fetch_and_execute(self, topic_names, action, process_variables=None, variables=None):
         self._log_with_context(f"Fetching and Executing external tasks for Topics: {topic_names} "
                                f"with Process variables: {process_variables}")
-        resp_json = self._fetch_and_lock(topic_names, process_variables, variables, use_priority)
+        resp_json = self._fetch_and_lock(topic_names, process_variables, variables)
         tasks = self._parse_response(resp_json, topic_names, process_variables)
         if len(tasks) == 0:
             raise NoExternalTaskFound(f"no External Task found for Topics: {topic_names}, "
                                       f"Process variables: {process_variables}")
         self._execute_tasks(tasks, action)
 
-    def _fetch_and_lock(self, topic_names, process_variables=None, variables=None, use_priority=False):
+    def _fetch_and_lock(self, topic_names, process_variables=None, variables=None):
         self._log_with_context(f"Fetching and Locking external tasks for Topics: {topic_names} "
                                f"with Process variables: {process_variables}")
-        return self.client.fetch_and_lock(topic_names, process_variables, variables, use_priority)
+        return self.client.fetch_and_lock(topic_names, process_variables, variables)
 
     def _parse_response(self, resp_json, topic_names, process_variables):
         tasks = []


### PR DESCRIPTION
This PR improves the fetch and lock method, possibiliting the user passing two more parameters to get a task:
1. usePriority
    * will fetch external tasks according your priority. When this value is `True`, will return the external task that have highest priority.
2. variables
    * will fetch only variables from external task that was passed in this list, i.e., some cases is not needed to get all variables from external task. When this one is `None`, all variables is fetched.
3. deserializeValues
    * will deserialize object values when fetch a task by default.
    example:
```python
{
    'my_object__bar': 'rO0ABXNyABNqYXZhLnV0aWwuQXJyYXlMaXN0eIHSHZnHYZ0DAAFJAARzaXpleHAAAAADdwQAAAADc3IAEWphdmEubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhqyVHQuU4IsCAAB4cAAAAAFzcQB+AAIAAAACc3EAfgACAAAAA3g=',
    'my_object__foo': 'hello-world',
    'my_object__other_object__lorem': 'ipsum'
}
```
turns in
```python
{
    'my_object__bar': [1, 2, 3],
    'my_object__foo': 'hello-world',
    'my_object__other_object__lorem': 'ipsum'
}
```

reference: https://docs.camunda.org/manual/7.16/reference/rest/external-task/fetch/#request-body